### PR TITLE
Fix kind cluster setup script on Mac

### DIFF
--- a/dev/setup-kind-cluster.sh
+++ b/dev/setup-kind-cluster.sh
@@ -3,14 +3,20 @@
 KIND_EXECUTABLE=kind
 KUBECTL_EXECUTABLE=kubectl
 CILIUM_EXECUTABLE=cilium-cli
+CILIUM_MAC_OS_EXECUTABLE=cilium 
+
+if [ "$(uname)" == "Darwin" ]; then
+  CILIUM_EXECUTABLE=cilium
+fi
+
 HELM_EXECUTABLE=helm
 
 # first check if the kind executable exists
 
 command -v $KIND_EXECUTABLE >/dev/null 2>&1 || { echo >&2 "I require '$KIND_EXECUTABLE' but it's not installed.  Aborting."; exit 1; }
 command -v $KUBECTL_EXECUTABLE >/dev/null 2>&1 || { echo >&2 "I require '$KUBECTL_EXECUTABLE' but it's not installed.  Aborting."; exit 1; }
-command -v $CILIUM_EXECUTABLE >/dev/null 2>&1 || { echo >&2 "I require '$CILIUM_EXECUTABLE' but it's not installed.  Aborting."; exit 1; }
-command -v $HELM_EXECUTABLE >/dev/null 2>&1 || { echo >&2 "I require '$CILIUM_EXECUTABLE' but it's not installed.  Aborting."; exit 1; }
+command -v $CILIUM_EXECUTABLE >/dev/null 2>&1 || command -v $CILIUM_MAC_OS_EXECUTABLE >/dev/null 2>&1  || { echo >&2 "I require '$CILIUM_EXECUTABLE' or '$CILIUM_MAC_OS_EXECUTABLE' but it's not installed.  Aborting."; exit 1; }
+command -v $HELM_EXECUTABLE >/dev/null 2>&1 || { echo >&2 "I require '$HELM_EXECUTABLE' but it's not installed.  Aborting."; exit 1; }
 
 # Create "kind" network, deleting any old ones if they exist
 


### PR DESCRIPTION
This pull request fixes the kind cluster setup script on Mac by updating the CILIUM_EXECUTABLE variable to use the correct executable name for macOS. Previously, the script was using the wrong executable name, causing the script to fail on macOS. This update ensures that the script works correctly on both Linux and macOS systems.